### PR TITLE
Add ALT text to medias

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -44,6 +44,7 @@ botClient.on(Events.MessageCreate, async (message) => {
 
                 let res = await fetch(attachment.url);
                 data.append("file", await res.blob());
+                data.append("description", attachment.description ?? "No ALT text available.")
 
                 let res2 = await fetch("https://social.lexevo.net/api/v2/media", {
                     method: "POST",


### PR DESCRIPTION
This PR adds ALT texts to medias.

If an ALT text is present, it will just add the media with it.
If none is available, it will instead set it to "No ALT text available.".